### PR TITLE
Allow implicit reexport

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,6 @@ disallow_untyped_defs = true
 exclude = "{{cookiecutter.project_name_kebab_case}}/"
 follow_imports = "silent"
 ignore_missing_imports = true
-no_implicit_reexport = true
 strict_optional = true
 warn_redundant_casts = true
 warn_unused_ignores = true

--- a/{{cookiecutter.project_name_kebab_case}}/pyproject.toml
+++ b/{{cookiecutter.project_name_kebab_case}}/pyproject.toml
@@ -92,7 +92,6 @@ disallow_any_generics = true
 disallow_untyped_defs = true
 follow_imports = "silent"
 ignore_missing_imports = true
-no_implicit_reexport = true
 strict_optional = true
 warn_redundant_casts = true
 warn_unused_ignores = true


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and review
the requirements below.

Bug fixes and new features should include tests and documentation.

Contributors guide: ./CONTRIBUTING.md
-->

### What are you changing?

Removing `no_implicit_reexport = true` from mypy configuration.

### Why are you making this change?

Having this option enabled prevents importing interval package modules.
