### PR TITLE
Fix format on save for python files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,5 +22,8 @@
     "python.linting.flake8Enabled": true,
     "python.linting.enabled": true,
     "python.formatting.provider": "black",
-    "python.linting.mypyEnabled": true
+    "python.linting.mypyEnabled": true,
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.python"
+    }
 }

--- a/{{cookiecutter.project_name_kebab_case}}/.vscode/settings.json
+++ b/{{cookiecutter.project_name_kebab_case}}/.vscode/settings.json
@@ -21,5 +21,8 @@
     "python.linting.flake8Enabled": true,
     "python.linting.enabled": true,
     "python.formatting.provider": "black",
-    "python.linting.mypyEnabled": true
+    "python.linting.mypyEnabled": true,
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.python"
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and review
the requirements below.

Bug fixes and new features should include tests and documentation.

Contributors guide: ./CONTRIBUTING.md
-->

### What are you changing?

Set vs code formatter to be used for python files.

Closes https://github.com/ali92hm/cookiecutter-pyproject/issues/20
