### PR TITLE
Use a dictionary for translating between license name and pyproject classifiers license strings

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -16,5 +16,14 @@
         "GNU General Public License Version 3",
         "Unlicense",
         "Not open source"
-    ]
+    ],
+    "_pypi_license_map": {
+        "MIT License": "License :: OSI Approved :: MIT License",
+        "BSD 2-Clause License": "License :: OSI Approved :: BSD License",
+        "BSD 3-Clause License": "License :: OSI Approved :: BSD License",
+        "ISC License": "License :: OSI Approved :: ISC License (ISCL)",
+        "Apache License Version 2.0": "License :: OSI Approved :: Apache Software License",
+        "GNU General Public License Version 3": "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "Unlicense": "License :: OSI Approved :: The Unlicense (Unlicense)"
+    }
 }

--- a/tests/integration/test_generator.py
+++ b/tests/integration/test_generator.py
@@ -28,6 +28,7 @@ def run_generated_project_assertions(generated_project, **kwargs):
         + f"{pre_gen_project.get_project_name_kebab_case(project_name)}"
     )
     license = cookie_cutter_file["license"][0]
+    pypi_license_map = cookie_cutter_file["_pypi_license_map"]
 
     # Replace these variables if an override is given
     if "project_name" in kwargs:
@@ -71,7 +72,7 @@ def run_generated_project_assertions(generated_project, **kwargs):
     assert generated_project.context["project_repo"] == project_repo
     assert generated_project.context["license"] == license
     # This is so when new variables are added/removed we know to add tests for them :)
-    assert len(generated_project.context) == 9
+    assert len(generated_project.context) == 10
 
     # make sure the project was generated correctly
     assert generated_project.exit_code == 0
@@ -162,18 +163,7 @@ def run_generated_project_assertions(generated_project, **kwargs):
         else:
             assert project_metadata["project"]["license"]["file"] == "LICENSE"
 
-        # TODO: Move this map as a private variable to cookiecutter.json when this
-        # https://github.com/cookiecutter/cookiecutter/issues/1582 is resolved
-        pypi_license_map = {
-            "MIT License": "License :: OSI Approved :: MIT License",
-            "BSD 2-Clause License": "License :: OSI Approved :: BSD License",
-            "BSD 3-Clause License": "License :: OSI Approved :: BSD License",
-            "ISC License": "License :: OSI Approved :: ISC License (ISCL)",
-            "Apache License Version 2.0": "License :: OSI Approved :: Apache Software License",
-            "GNU General Public License Version 3": "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-            "Unlicense": "License :: OSI Approved :: The Unlicense (Unlicense)",
-            "Not open source": "",
-        }
+        assert "" not in project_metadata["project"]["classifiers"]
 
         if license != "Not open source":
             assert (

--- a/{{cookiecutter.__project_name_kebab_case}}/pyproject.toml
+++ b/{{cookiecutter.__project_name_kebab_case}}/pyproject.toml
@@ -14,21 +14,8 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Operating System :: OS Independent",
-  {% if cookiecutter.license == 'MIT License' -%}
-  "License :: OSI Approved :: MIT License",
-  {%- elif cookiecutter.license == 'BSD 2-Clause License' -%}
-  "License :: OSI Approved :: BSD License",
-  {%- elif cookiecutter.license == 'BSD 3-Clause License' -%}
-  "License :: OSI Approved :: BSD License",
-  {%- elif cookiecutter.license == 'ISC License' -%}
-  "License :: OSI Approved :: ISC License (ISCL)",
-  {%- elif cookiecutter.license == 'Apache License Version 2.0' -%}
-  "License :: OSI Approved :: Apache Software License",
-  {%- elif cookiecutter.license == 'GNU General Public License Version 3' -%}
-  "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-  {%- elif cookiecutter.license == 'Unlicense' -%}
-  "License :: OSI Approved :: The Unlicense (Unlicense)",
-  {%- endif %}
+  {% if cookiecutter.license != 'Not open source' %}"{{ cookiecutter._pypi_license_map[cookiecutter.license] }}",
+  {% endif -%}
   "Typing :: Typed",
 ]
 
@@ -39,9 +26,8 @@ description = "{{ cookiecutter.project_description }}"
 keywords = [
   # fill me
 ]
-{% if cookiecutter.license != 'Not open source' -%}
-license = {file = "LICENSE"}
-{%- endif %}
+{% if cookiecutter.license != 'Not open source' -%}license = {file = "LICENSE"}
+{% endif -%}
 maintainers = [
   {name = "{{ cookiecutter.author_full_name }}", email = "{{ cookiecutter.author_email }}"},
 ]


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and review
the requirements below.

Bug fixes and new features should include tests and documentation.

Contributors guide: ./CONTRIBUTING.md
-->

### What are you changing?

Added `_pypi_license_map` for translating between license name and pyproject classifiers license strings.


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] Tests are included
-   [ ] Documentation is changed or added
-   [ ] Added a summary of changed to ./CHANGELOG.md
-   Only of of these should be marked
    -   [ ] My changes only include bug fixes
    -   [x] My changes **are backwards** compatible and I've bumped the minor version in `pyproject.toml`
    -   [ ] My changes **are not backwards** compatible and I've bumped the major version in `pyproject.toml`
